### PR TITLE
Fully qualified name for R class, allowing Activities in subpackages

### DIFF
--- a/Xtendroid/src/org/xtendroid/app/AndroidActivity.xtend
+++ b/Xtendroid/src/org/xtendroid/app/AndroidActivity.xtend
@@ -19,8 +19,8 @@ import java.lang.annotation.ElementType
 /**
  * An active annotation for Android activities.
  * 
- * It takes one argument value, which is the simple name of the associated view file.
- * e.g. for layout/main_view.xml, the simple name would be "main_view".
+ * It takes one argument layout, which is the resource identifier of the associated view file.
+ * e.g. for layout/main_view.xml, the simple name would be "R.id.main_view".
  * 
  * It automatically declares typed local fields for all members declared within that XML layout, that is each member
  * with an @id/name attribute will be accessible from within the annotated classes without further ado.
@@ -31,7 +31,7 @@ import java.lang.annotation.ElementType
 @Active(AndroidActivityProcessor)
 @Target(ElementType.TYPE)
 annotation AndroidActivity {
-   String value
+   int layout
 }
 
 class AndroidActivityProcessor extends AbstractClassProcessor {
@@ -42,7 +42,9 @@ class AndroidActivityProcessor extends AbstractClassProcessor {
    
    override doTransform(MutableClassDeclaration annotatedClass, extension TransformationContext context) {
       val callBacksType = findInterface(annotatedClass.qualifiedName+"_CallBacks")
-      val viewFileName = getValue(annotatedClass, context)
+      val layoutResourceID = getValue(annotatedClass, context)
+       
+      val viewFileName = layoutResourceID.substring(layoutResourceID.lastIndexOf('.') + 1)
       if (viewFileName == null) {
          return;
       }
@@ -52,8 +54,6 @@ class AndroidActivityProcessor extends AbstractClassProcessor {
          annotatedClass.annotations.head.addError("There is no file in '"+xmlFile+"'.")
          return;
       }
-      
-      val packageResource = getPackageNameForResourceClass(annotatedClass.qualifiedName)
       
       // add 'extends Activity' if necessary
       if (annotatedClass.extendedClass == Object.newTypeReference()) {
@@ -85,7 +85,7 @@ class AndroidActivityProcessor extends AbstractClassProcessor {
             addParameter("savedInstanceState", Bundle.newTypeReference)
             body = ['''
                super.onCreate(savedInstanceState);
-               setContentView(«packageResource»R.layout.«viewFileName»);
+               setContentView(«layoutResourceID»);
                «FOR method : onCreateMethods»
                   «method.simpleName»(savedInstanceState);
                «ENDFOR»
@@ -105,7 +105,7 @@ class AndroidActivityProcessor extends AbstractClassProcessor {
             annotatedClass.addMethod('get'+name.toFirstUpper) [
                returnType = fieldType
                body = ['''
-                  return («toJavaCode(fieldType)») findViewById(«packageResource»R.id.«id»);
+                  return («toJavaCode(fieldType)») findViewById(R.id.«id»);
                ''']
             ]
          }
@@ -123,8 +123,11 @@ class AndroidActivityProcessor extends AbstractClassProcessor {
    def String getValue(MutableClassDeclaration annotatedClass, extension TransformationContext context) {
       val value = annotatedClass.annotations.findFirst[
          annotationTypeDeclaration==AndroidActivity.newTypeReference.type
-      ].getValue("value") as String
-      return value
+      ].getExpression("layout")
+      
+      if (value == null) return null
+      
+      return value.toString
    }
      
    def getFieldType(Element e) {
@@ -157,24 +160,5 @@ class AndroidActivityProcessor extends AbstractClassProcessor {
          return id.substring(5)
       }
       return null
-   }
-   
-   def String getPackageNameForResourceClass(String packageName) {
-      if (packageName == null || packageName == "") 
-         return ""
-    
-      try {
-         // let's try to load the R class
-         Class.forName(packageName + ".R") 
-          
-         return packageName + "."
-      } catch (ClassNotFoundException exception) {
-         // R class not found, trying on parent 
-         val lastDotPosition = packageName.lastIndexOf('.')
-         if (lastDotPosition < 0) 
-            return "";
-    
-         return getPackageNameForResourceClass(packageName.substring(0, lastDotPosition));
-      }
    }
 }


### PR DESCRIPTION
As mentioned in #1, there's a bug when an Activity isn't in the same package as the generated R class. This pull request fixes that. 

**Note:** the bug still happens if the R class doesn't belong to a parent package of the activity, like `org.foo.R` and `com.bar.activities.MyActivity`. In that case, the generated java file would have the same error as the version without the patch.
