### PR TITLE
AndroidActivity now accepts more classes from layout files

### DIFF
--- a/Xtendroid/src/org/xtendroid/app/AndroidActivity.xtend
+++ b/Xtendroid/src/org/xtendroid/app/AndroidActivity.xtend
@@ -137,10 +137,16 @@ class AndroidActivityProcessor extends AbstractClassProcessor {
          try {
             Class.forName("android.view."+e.nodeName)
          } catch (ClassNotFoundException exception1) {
-            null
+            try {
+            	Class.forName(e.nodeName)
+	         } catch (ClassNotFoundException exception2) {
+	         	null
+             }
          }
       }
-      if (View.isAssignableFrom(clazz)) {
+      
+      
+      if (clazz != null && View.isAssignableFrom(clazz)) {
          return clazz
       }
       return null


### PR DESCRIPTION
Now the `AndroidActivity` annotation accepts custom classes (eg.: `android.support.v4.view.ViewPager`) in layout XML files and it does not die horribly when a class is not found in the classpath (I think it should throw an error in that case).
