### PR TITLE
Added convenience @AddLogTag annotation

### DIFF
--- a/Xtendroid/src/org/xtendroid/annotations/LogTag.xtend
+++ b/Xtendroid/src/org/xtendroid/annotations/LogTag.xtend
@@ -4,8 +4,11 @@ import org.eclipse.xtend.lib.macro.Active
 import org.eclipse.xtend.lib.macro.AbstractClassProcessor
 import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration
 import org.eclipse.xtend.lib.macro.TransformationContext
+import java.lang.annotation.Target
+import java.lang.annotation.ElementType
 
 @Active(typeof(LogTagProcessor))
+@Target(ElementType.TYPE)
 annotation AddLogTag {
 	String value = ""
 }


### PR DESCRIPTION
During the debugging process, one would like to create a final static String TAG = "someclassname"...  for the Log invocations.

This minimizes the hassle involved.
