### PR TITLE
removed pointless warning

### DIFF
--- a/Xtendroid/src/org/xtendroid/parcel/ParcelableProperty.xtend
+++ b/Xtendroid/src/org/xtendroid/parcel/ParcelableProperty.xtend
@@ -203,22 +203,6 @@ class ParcelableProcessor extends AbstractClassProcessor
 			{
 				f.addError (String.format("%s has the type %s, it may not be used with @AndroidParcelable. Use %s instead.", f.simpleName, f.type.name, ParcelableProcessor.unsupportedAbstractTypesAndSuggestedTypes.get(f.type.name)))
 			}
-			
-			if (!jsonPropertyFieldDeclared && f.annotations.exists[a | a.annotationTypeDeclaration.simpleName.endsWith('JsonProperty') ])//.equals(JsonProperty.newAnnotationReference)])
-			{
-				f.addWarning (String.format("%s has certain fields that are annotated with @JsonProperty, you have to declare the %s field explicitly, initialized in the ctor as well to prevent data loss when passing the data object between Activities/Services etc.\nFor example:\n%s", f.declaringType.simpleName, JsonPropertyProcessor.jsonObjectFieldName,
-				// the gist of the story is to explicitly declare a type like this
-					'''
-						@AndroidParcelable
-						class C implements Parcelable
-						{
-							JSONObject «JsonPropertyProcessor.jsonObjectFieldName»
-							
-							@JsonProperty
-							String meh
-						}
-					'''))
-			}		
 		}
 		
 		// @Override public int describeContents() { return 0; }
@@ -229,7 +213,6 @@ class ParcelableProcessor extends AbstractClassProcessor
 				return 0;
 			'''
 		]
-		
 
 		clazz.addMethod("writeToParcel")  [
 			returnType = void.newTypeReference


### PR DESCRIPTION
Hi,

The warning I removed with this patch is pointless since JSON objects are persisted out-of-the-box. (Evidently I built this a while ago).

Thanks for your attention.

Please review and pull.
