### PR TITLE
Field support for @AndroidResources with parameterizable xml path and resource type

### DIFF
--- a/Xtendroid/src/org/xtendroid/annotations/EnumProperty.xtend
+++ b/Xtendroid/src/org/xtendroid/annotations/EnumProperty.xtend
@@ -67,7 +67,7 @@ class EnumPropertyProcessor extends AbstractFieldProcessor {
 		    		)
 	}
 			
-	def getPackageNameFromField(FieldDeclaration field) {
+	def dispatch getPackageNameFromField(FieldDeclaration field) {
 		val fieldTypeSimpleName = field.declaringType.simpleName
 		val fieldTypeName = field.declaringType.qualifiedName
 		val package = fieldTypeName.replace(fieldTypeSimpleName, '')

--- a/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
+++ b/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
@@ -1,20 +1,30 @@
 package org.xtendroid.content.res
 
 import android.content.res.Resources
+import android.content.Context
 import java.text.DateFormat
 import java.text.MessageFormat
 import java.text.NumberFormat
 import java.util.Date
-import org.eclipse.xtend.lib.macro.AbstractClassProcessor
 import org.eclipse.xtend.lib.macro.Active
 import org.eclipse.xtend.lib.macro.TransformationContext
 import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration
 import org.eclipse.xtend.lib.macro.declaration.Visibility
 import org.xtendroid.utils.NamingUtils
 
-import static extension org.xtendroid.utils.XmlUtils.*
+import java.lang.annotation.ElementType
+import java.lang.annotation.Target
+import java.util.List
+import org.eclipse.xtend.lib.macro.declaration.MutableMemberDeclaration
+import org.eclipse.xtend.lib.macro.TransformationParticipant
+import org.eclipse.xtend.lib.macro.declaration.FieldDeclaration
+import org.eclipse.xtend.lib.macro.declaration.MutableFieldDeclaration
 
-/**
+import static extension org.xtendroid.utils.XmlUtils.*
+import org.eclipse.xtend.lib.macro.RegisterGlobalsParticipant
+import org.eclipse.xtend.lib.macro.RegisterGlobalsContext
+
+/*
  * An annotation that generates accessor methods to Android string resources.
  * 
  * <p>It uses java's @link{java.text.MessageFormat} in the values and the accessor methods will sport typed parameters according to the placeholders.
@@ -28,11 +38,21 @@ import static extension org.xtendroid.utils.XmlUtils.*
  * </code>
  */
 @Active(AndroidResourcesProcessor)
-annotation AndroidResources {}
+@Target(value=#[ElementType.FIELD, ElementType.TYPE])
+annotation AndroidResources {
+    Class<?> type = Object // e.g. R.string, R.integer, R.boolean
+    String path = "build/intermediates/res/merged/debug/values/values.xml" // where everything is merged together
+}
 
-class AndroidResourcesProcessor extends AbstractClassProcessor {
+class AndroidResourcesProcessor implements TransformationParticipant<MutableMemberDeclaration>, RegisterGlobalsParticipant {
 
-   override doTransform(MutableClassDeclaration annotatedClass, extension TransformationContext context) {
+
+    /**
+     *
+     * Transform a pojo class to support getters for resources
+     *
+     */
+    def dispatch void transform(MutableClassDeclaration annotatedClass, extension TransformationContext context) {
       val resourcesType = Resources.newTypeReference
       if (annotatedClass.findDeclaredMethod("getResources", resourcesType) == null) {
          annotatedClass.addMethod('getResources') [
@@ -43,6 +63,13 @@ class AndroidResourcesProcessor extends AbstractClassProcessor {
          annotatedClass.abstract = true
       }
 
+      // Does this work with new style android gradle default file structure?
+      // This should be parameterizable, to support something like:
+      // ./XtendroidTest/build/intermediates/res/merged/release/values/values.xml,
+      // because everything is merged here, and there is no guarantee that strings are stored in strings.xml
+      // these could be placed into e.g. strings1.xml, strings2.xml, moar-strings.xml, tanga.xml
+      // also there are no guarantees that these will be put into res/values either e.g.
+      // res/values-<language>-<resolution>-<blah> are also valid locations
       val stringsPath = annotatedClass.compilationUnit.filePath.projectFolder.append("res/values/strings.xml")
       if (stringsPath.exists) {
          stringsPath.contentsAsStream.document.traverseAllNodes [
@@ -88,5 +115,183 @@ class AndroidResourcesProcessor extends AbstractClassProcessor {
       }
 
    }
+
+    val mapResourceTypeToGetMethod = #{
+        'R.string' -> 'getString'
+        , 'R.color' -> 'getColor'
+        , 'R.dimen' -> 'getDimension'
+        , 'R.bool' -> 'getBoolean' // TODO see also getBooleanArray... or something
+        , 'R.integer' -> 'getInteger'
+        //, 'R.fraction' -> 'getFraction' // tricky bugger
+    }
+
+    val mapResourceTypeReturnType = #{
+        'R.string' -> String
+        , 'R.color' -> Float
+        , 'R.dimen' -> Float
+        , 'R.bool' -> Boolean // TODO see also getBooleanArray... or something
+        , 'R.integer' -> Integer
+        //, 'R.fraction' -> '?' // tricky bugger
+    }
+
+    def parseXmlAndGenerateGetters (MutableClassDeclaration annotatedClass, String xmlPath, String resourceTypeName, extension TransformationContext context)
+    {
+        val xmlSource = annotatedClass.compilationUnit.filePath.projectFolder.append(xmlPath)
+
+        if (!xmlSource.exists) {
+            annotatedClass.addError(String.format("The xml %s path does not exist", xmlPath)) // TODO throw exception, catch it in the calling method?
+            return // get out
+        }
+
+        if (!resourceTypeName.startsWith('R.')) {
+            annotatedClass.addError('The resource type must start with R. (e.g. R.string, R.integer etc.)')
+        }
+        val resourceNodeName = resourceTypeName.replaceFirst("R.", '')
+
+        // import package.R
+        val resourceType = resourceTypeName.findTypeGlobally.newTypeReference
+
+        xmlSource.contentsAsStream.document.traverseAllNodes [
+            if (nodeName == resourceNodeName) {
+                val name = getAttribute('name')
+                annotatedClass.addMethod("get" + NamingUtils.toJavaIdentifier(name).toFirstUpper) [
+                    returnType = mapResourceTypeReturnType.get(resourceTypeName).newTypeReference
+                    body = [
+                        '''
+                        return mResources.«mapResourceTypeToGetMethod.get(resourceTypeName)»(«toJavaCode(resourceType)».«name»);
+                        '''
+                    ]
+                ]
+            }
+        ]
+    }
+
+    /*
+
+    Usage:
+
+    1. Apply to any type (Activity, Fragment, View, Poxo) type pray you don't have a name collision
+    2. Apply to a member variable
+
+    val drawables (..., ...)
+    val colors (<color>, int getColor)
+    val dimens (<dimen>, float getDimension)
+    val bool (<bool>, boolean getBoolean)
+    val integer (<integer>, int getInteger)
+    val array (<integer-array>, int[] getIntArray)
+    val fraction (<item type="fraction">, ... getFraction)
+
+
+    @AndroidResources(type=R.string)
+    var strings
+
+    @AndroidResources(type=R.drawable)
+    var drawables
+
+    @AndroidResources(type=R.color)
+    var colors
+
+    @AndroidResources(type=R.dimen)
+    var dimens
+
+    @AndroidResources(type=R.bool)
+    var booleans
+
+    @AndroidResources(type=R.integer)
+    var integers
+
+    @AndroidResources(type=R.fraction)
+    var fractions
+
+
+     */
+
+    val androidResourcesString = "AndroidResources"
+    def dispatch void transform(MutableFieldDeclaration field, extension TransformationContext context) {
+
+        val annotation = field.annotations.findFirst[ androidResourcesString.equals(annotationTypeDeclaration.simpleName) ]
+
+        // determine the resource type
+        val resourceTypeName = annotation.getExpression("type").toString
+
+        // field name == resource class name
+        val resourceHelperClassName = field.packageNameFromField + field.simpleName.toFirstUpper
+        val resourceHelperClass = context.findClass(resourceHelperClassName)
+
+        // DIY if you want android.R (this is merged eventually), choose your xml path wisely
+        if (resourceTypeName.contains('drawable'))
+        {
+            // TODO file based, not xml
+        }else
+        {
+            parseXmlAndGenerateGetters(resourceHelperClass, annotation.getStringValue('path'), resourceTypeName, context)
+        }
+
+        // determine that host class is an Activity, Fragment, Pojc
+        // then adapt the Context#getResources injection method
+        // where to get the inflater
+        resourceHelperClass.addField("mContext") [
+            visibility = Visibility.PRIVATE
+            type = Context.newTypeReference
+            final = true
+        ]
+
+        resourceHelperClass.addField("mResources") [
+            visibility = Visibility.PRIVATE
+            type = Resources.newTypeReference
+            final = true
+        ]
+
+        resourceHelperClass.addConstructor [
+            visibility = Visibility::PUBLIC
+            body = [
+                '''
+                    this.mContext = context;
+                    this.mResources = mContext.getResources();
+				''']
+            addParameter("context", Context.newTypeReference)
+        ]
+
+        // instantiate resource helper object
+        field.initializer = '''new «field.simpleName.toFirstUpper»(this)''' // TODO when instantiating in a fragment or poxo, change 'this' to something else
+        field.type = resourceHelperClass.newTypeReference
+        field.final = true
+    }
+
+    override doTransform(List<? extends MutableMemberDeclaration> list, TransformationContext context) {
+        list.forEach[ transform(context) ]
+    }
+
+    /**
+     *
+     * Create a new type based on the R.<type>
+     *
+     */
+    override doRegisterGlobals(List list, RegisterGlobalsContext context) {
+
+        for (m : list)
+        {
+            try {
+                val field = m as FieldDeclaration
+
+                val fullClassName = field.packageNameFromField + field.simpleName.toFirstUpper
+                if (context.findSourceClass(fullClassName) == null)
+                {
+                    // register only once, this assumption holds unless you sneakily change e.g. values.xml
+                    // mid-transpilation
+                    context.registerClass(fullClassName)
+                }
+            } catch (ClassCastException ex) { /* continue */ }
+        }
+    }
+
+    // TODO remove duplicate in EnumProperty
+    def dispatch getPackageNameFromField(FieldDeclaration field) {
+        val fieldTypeSimpleName = field.declaringType.simpleName
+        val fieldTypeName = field.declaringType.qualifiedName
+        val package = fieldTypeName.replace(fieldTypeSimpleName, '')
+        package
+    }
+
 
 }

--- a/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
+++ b/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
@@ -173,38 +173,7 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
     1. Apply to any type (Activity, Fragment, View, Poxo) type pray you don't have a name collision
     2. Apply to a member variable
 
-    val drawables (..., ...)
-    val colors (<color>, int getColor)
-    val dimens (<dimen>, float getDimension)
-    val bool (<bool>, boolean getBoolean)
-    val integer (<integer>, int getInteger)
-    val array (<integer-array>, int[] getIntArray)
-    val fraction (<item type="fraction">, ... getFraction)
-
-
-    @AndroidResources(type=R.string)
-    var strings
-
-    @AndroidResources(type=R.drawable)
-    var drawables
-
-    @AndroidResources(type=R.color)
-    var colors
-
-    @AndroidResources(type=R.dimen)
-    var dimens
-
-    @AndroidResources(type=R.bool)
-    var booleans
-
-    @AndroidResources(type=R.integer)
-    var integers
-
-    @AndroidResources(type=R.fraction)
-    var fractions
-
-
-     */
+    */
 
     val androidResourcesString = "AndroidResources"
     def dispatch void transform(MutableFieldDeclaration field, extension TransformationContext context) {

--- a/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
+++ b/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
@@ -65,7 +65,7 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
 
       // Does this work with new style android gradle default file structure?
       // This should be parameterizable, to support something like:
-      // ./XtendroidTest/build/intermediates/res/merged/release/values/values.xml,
+      // ./XtendroidTest/build/intermediates/res/merged/debug/values/values.xml,
       // because everything is merged here, and there is no guarantee that strings are stored in strings.xml
       // these could be placed into e.g. strings1.xml, strings2.xml, moar-strings.xml, tanga.xml
       // also there are no guarantees that these will be put into res/values either e.g.
@@ -127,7 +127,7 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
 
     val mapResourceTypeReturnType = #{
         'R.string' -> String
-        , 'R.color' -> Float
+        , 'R.color' -> Integer
         , 'R.dimen' -> Float
         , 'R.bool' -> Boolean // TODO see also getBooleanArray... or something
         , 'R.integer' -> Integer
@@ -266,6 +266,8 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
      *
      * Create a new type based on the R.<type>
      *
+     * This must hold: assertTrue(field.simpleName.equals(field.declaringType.simpleName))
+     *
      */
     override doRegisterGlobals(List list, RegisterGlobalsContext context) {
 
@@ -274,6 +276,8 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
             try {
                 val field = m as FieldDeclaration
 
+                // assertTrue(field.simpleName.equals(field.declaringType.simpleName))
+                // because field doesn't have a type yet during this pass
                 val fullClassName = field.packageNameFromField + field.simpleName.toFirstUpper
                 if (context.findSourceClass(fullClassName) == null)
                 {

--- a/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
+++ b/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
@@ -253,8 +253,24 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
             addParameter("context", Context.newTypeReference)
         ]
 
+        /*
+        if (field...extendedClass.equals(Context.newTypeReference) {
+            field.initializer = '''new «field.simpleName.toFirstUpper»(this)''' // TODO when instantiating in an Activity or Service
+        }else if (field...extendedClass.equals(android.app.Fragment.newTypeReference)) { // api level >=11, TODO also add supportlib support
+        {
+            field.initializer = '''new «field.simpleName.toFirstUpper»(getActivity())''' // TODO when instantiating in a fragment
+        }else if (field...extendedClass.equals(	android.view.View.newTypeReference)) {
+        {
+            field.initializer = '''new «field.simpleName.toFirstUpper»(mContext)''' // TODO when instantiating in a custom view
+        }else
+        {
+            clazz.addWarning("Currently the use-case beyond Activity/Service/View is out-of-scope.")
+            return // get out, you're on your own
+        }
+        */
+
         // instantiate resource helper object
-        field.initializer = '''new «field.simpleName.toFirstUpper»(this)''' // TODO when instantiating in a fragment or poxo, change 'this' to something else
+        field.initializer = '''new «field.simpleName.toFirstUpper»(this)''' // TODO see the code block above, right now we only support Activity
         field.type = resourceHelperClass.newTypeReference
         field.final = true
     }

--- a/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
+++ b/Xtendroid/src/org/xtendroid/content/res/AndroidResources.xtend
@@ -171,6 +171,10 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
                     returnType = mapResourceTypeToReturnType.get(resourceTypeName).newTypeReference
                     body = [
                         '''
+                        if (mResources == null)
+                        {
+                            mResources = mContext.getResources();
+                        }
                         return mResources.«mapResourceTypeToGetMethod.get(resourceTypeName)»(«toJavaCode(resourceType)».«name»);
                         '''
                     ]
@@ -184,6 +188,10 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
                     returnType = mapAggregateResourceTypeReturnType.get(aggregateResourceNodeName).newTypeReference.newArrayTypeReference
                     body = [
                         '''
+                        if (mResources == null)
+                        {
+                            mResources = mContext.getResources();
+                        }
                         return mResources.«mapAggregateResourceTypeToGetMethod.get(aggregateResourceNodeName)»(R.array.«name»);
                         '''
                     ]
@@ -234,7 +242,6 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
         resourceHelperClass.addField("mResources") [
             visibility = Visibility.PRIVATE
             type = Resources.newTypeReference
-            final = true
         ]
 
         resourceHelperClass.addConstructor [
@@ -242,7 +249,6 @@ class AndroidResourcesProcessor implements TransformationParticipant<MutableMemb
             body = [
                 '''
                     this.mContext = context;
-                    this.mResources = mContext.getResources();
 				''']
             addParameter("context", Context.newTypeReference)
         ]

--- a/XtendroidTest/AndroidManifest.xml
+++ b/XtendroidTest/AndroidManifest.xml
@@ -45,6 +45,7 @@
             android:configChanges="keyboardHidden|orientation|screenSize" />
         <activity android:name="org.xtendroid.xtendroidtest.activities.ParcelableActivity" />
         <activity android:name="org.xtendroid.xtendroidtest.activities.BundleActivity" />
+        <activity android:name="org.xtendroid.xtendroidtest.activities.AndroidResourcesActivity" />
     </application>
 
 </manifest>

--- a/XtendroidTest/res/values/strings.xml
+++ b/XtendroidTest/res/values/strings.xml
@@ -5,5 +5,19 @@
     <string name="action_settings">Settings</string>
     <string name="hello_world">Hello, Xtendroid</string>
     <string name="welcome">Xtendroid API demos and tests</string>
+
+    <string-array name="array_of_strings">
+        <item>one</item>
+        <item>two</item>
+        <item>two</item>
+    </string-array>
+
+    <integer-array name="powers_of_two">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>4</item>
+        <item>8</item>
+    </integer-array>
     
 </resources>

--- a/XtendroidTest/src/org/xtendroid/xtendroidtest/activities/AndroidResourcesActivity.xtend
+++ b/XtendroidTest/src/org/xtendroid/xtendroidtest/activities/AndroidResourcesActivity.xtend
@@ -1,0 +1,80 @@
+package org.xtendroid.xtendroidtest.activities
+
+import org.xtendroid.app.AndroidActivity
+import org.xtendroid.xtendroidtest.R
+import org.xtendroid.app.OnCreate
+import org.xtendroid.content.res.AndroidResources
+import org.xtendroid.xtendroidtest.BuildConfig
+
+/**
+ * Created by jasmsison on 26/12/15.
+ */
+@AndroidActivity(R.layout.activity_main)
+class AndroidResourcesActivity {
+
+    /**
+     * Tree-shaking during the dex process will remove unnecessary methods/classes
+     */
+
+    @AndroidResources(type=R.string)
+    var Strings strings
+
+    @AndroidResources(type=R.integer)
+    var Integers integers
+
+    @AndroidResources(type=R.color)
+    var Colors colors
+
+    @AndroidResources(type=R.dimen)
+    val Dimens dimens
+
+    @AndroidResources(type=R.bool)
+    val Bools bools
+
+    @AndroidResources(type=R.string, path="build/intermediates/res/merged/release/values/values.xml")
+    var Strings1 strings1
+
+    @AndroidResources(type=R.integer, path="build/intermediates/res/merged/release/values/values.xml")
+    var Integers1 integers1
+
+    @AndroidResources(type=R.color, path="build/intermediates/res/merged/release/values/values.xml")
+    var Colors1 colors1
+
+    @AndroidResources(type=R.dimen, path="build/intermediates/res/merged/release/values/values.xml")
+    val Dimens1 dimens1
+
+    @AndroidResources(type=R.bool, path="build/intermediates/res/merged/release/values/values.xml")
+    val Bools1 bools1
+
+/*
+R
+R.anim
+R.animator
+R.array
+R.attr
+R.bool
+R.color
+R.dimen
+R.drawable
+R.fraction
+R.id
+R.integer
+R.interpolator
+R.layout
+R.menu
+R.mipmap
+R.plurals
+R.raw
+R.string
+R.style
+R.styleable
+R.transition
+R.xml
+*/
+
+    @OnCreate
+    def init()
+    {
+
+    }
+}

--- a/XtendroidTest/src/org/xtendroid/xtendroidtest/activities/MainActivity.xtend
+++ b/XtendroidTest/src/org/xtendroid/xtendroidtest/activities/MainActivity.xtend
@@ -14,15 +14,16 @@ import org.xtendroid.adapter.BeanAdapter
 @AndroidActivity(R.layout.activity_main) class MainActivity {
 	// Xtendroid API demos
 	var demos = #[
-      new Demo('AsyncBuilder', BgTaskActivity),
+		new Demo('AsyncBuilder', BgTaskActivity),
 		new Demo('@AndroidFragment', FragmentActivity),
-      new Demo('@AndroidDialogFragment', DialogFragmentActivity),
+		new Demo('@AndroidDialogFragment', DialogFragmentActivity),
 		new Demo('@AndroidDatabase', DbTestActivity),
 		new Demo('@AndroidAdapter', AndroidAdapterActivity),
 		new Demo('@AndroidPreference', SettingsActivity),
 		new Demo('@AndroidLoader', LoaderActivity),
 		new Demo('@AndroidParcelable', ParcelableActivity),
-      new Demo('@BundleProperty', BundleActivity)
+		new Demo('@BundleProperty', BundleActivity),
+		new Demo('@AndroidResources', AndroidResourcesActivity)
 	]
 	
 	@OnCreate


### PR DESCRIPTION
Hi,

I provided MutableField support for @AndroidResources with parameterizable xml path and resource type.

I left the original @AndroidResources logic well alone. I saw the hardcoded paths etc.

Please review.

Thanks