### PR TITLE
whoops, 

### DIFF
--- a/XtendroidTest/src/org/xtendroid/xtendroidtest/activities/AndroidResourcesActivity.xtend
+++ b/XtendroidTest/src/org/xtendroid/xtendroidtest/activities/AndroidResourcesActivity.xtend
@@ -31,19 +31,19 @@ class AndroidResourcesActivity {
     @AndroidResources(type=R.bool)
     val Bools bools
 
-    @AndroidResources(type=R.string, path="build/intermediates/res/merged/release/values/values.xml")
+    @AndroidResources(type=R.string, path="build/intermediates/res/merged/debug/values/values.xml")
     var Strings1 strings1
 
-    @AndroidResources(type=R.integer, path="build/intermediates/res/merged/release/values/values.xml")
+    @AndroidResources(type=R.integer, path="build/intermediates/res/merged/debug/values/values.xml")
     var Integers1 integers1
 
-    @AndroidResources(type=R.color, path="build/intermediates/res/merged/release/values/values.xml")
+    @AndroidResources(type=R.color, path="build/intermediates/res/merged/debug/values/values.xml")
     var Colors1 colors1
 
-    @AndroidResources(type=R.dimen, path="build/intermediates/res/merged/release/values/values.xml")
+    @AndroidResources(type=R.dimen, path="build/intermediates/res/merged/debug/values/values.xml")
     val Dimens1 dimens1
 
-    @AndroidResources(type=R.bool, path="build/intermediates/res/merged/release/values/values.xml")
+    @AndroidResources(type=R.bool, path="build/intermediates/res/merged/debug/values/values.xml")
     val Bools1 bools1
 
 /*


### PR DESCRIPTION
Hi,

I noticed that I introduced a bug, in the test activity for `@AndroidResources`.
In the clean state of (gradle :XtendroidTest:clean), `res/merged/release/values` doesn't exist yet.

So this will block the first attempt to compile. Unless you already have a `res/merged/release/values` from a previous build.

Sorry!